### PR TITLE
Don't #error during completion

### DIFF
--- a/src/yaml/Parser.hx
+++ b/src/yaml/Parser.hx
@@ -1994,7 +1994,7 @@ class Parser
 		hash;
 	};
 
-	#if (neko || cpp)
+	#if (neko || cpp || display)
 	public static var PATTERN_NON_PRINTABLE         = ~/[\x{00}-\x{08}\x{0B}\x{0C}\x{0E}-\x{1F}\x{7F}-\x{84}\x{86}-\x{9F}\x{FFFE}\x{FFFF}]/u;
 	#elseif (js || flash9 || java)
 	public static var PATTERN_NON_PRINTABLE         = ~/[\x00-\x08\x0B\x0C\x0E-\x1F\x7F-\x84\x86-\x9F\uD800-\uDFFF\uFFFE\uFFFF]/u;	
@@ -2002,7 +2002,7 @@ class Parser
 	#error "Compilation target not supported due to lack of Unicode RegEx support."
 	#end
 	
-	#if (neko || cpp)
+	#if (neko || cpp || display)
 	public static var PATTERN_NON_ASCII_LINE_BREAKS = ~/[\x{85}\x{2028}\x{2029}]/u;
 	#elseif (js || flash9 || java)
 	public static var PATTERN_NON_ASCII_LINE_BREAKS = ~/[\x85\u2028\u2029]/u;


### PR DESCRIPTION
A .hxml file only used for completion might not define a target. Since the values don't matter much there, we can just fall back to something that at least parses and avoid breaking completion.

Example:

https://github.com/vshaxe/vshaxe/commit/a351d286cf4b3bcb13fa143348a9c456d107374d#diff-7c45353abd7bc95c3295a8afc48a11b8R5