### PR TITLE
Fix compatibility with latest Haxe 4

### DIFF
--- a/src/yaml/YamlException.hx
+++ b/src/yaml/YamlException.hx
@@ -4,10 +4,10 @@ import haxe.PosInfos;
 
 class YamlException
 {
-	public var name(get_name, null):String;
+	public var name(get, null):String;
 	function get_name():String { return name; }
 
-	public var message(get_message, null):String;
+	public var message(get, null):String;
 	function get_message():String { return message; }
 
 	public var cause(default, null):Dynamic;


### PR DESCRIPTION
Haxe 4 removes support for the Haxe 2 style property syntax, see HaxeFoundation/haxe#4699. With current dev builds of Haxe, this leads to the following errors:

```
C:\HaxeToolkit\haxe\lib\yaml/1,3,0/yaml/YamlException.hx:7: characters 2-41 : name: Custom property accessor is no longer supported, please use get
C:\HaxeToolkit\haxe\lib\yaml/1,3,0/yaml/YamlException.hx:10: characters 2-47 : message: Custom property accessor is no longer supported, please use get
```