### PR TITLE
Fix __js__ and Utf8 deprecation warnings

### DIFF
--- a/src/yaml/Parser.hx
+++ b/src/yaml/Parser.hx
@@ -1980,9 +1980,13 @@ class Parser
 	
 	static function createUtf8Char(hex:Int):String
 	{
+		#if haxe4
+		return String.fromCharCode(hex);
+		#else
 		var utf8 = new Utf8(1);
 		utf8.addChar(hex);
 		return utf8.toString();
+		#end
 	}
 
 	public static var HEXADECIMAL_ESCAPE_SEQUENCES:IntMap<Int> = 

--- a/src/yaml/type/YTimestamp.hx
+++ b/src/yaml/type/YTimestamp.hx
@@ -116,7 +116,11 @@ class YTimestamp extends YamlType<Date, String>
 		#elseif flash
 		return untyped _global["Date"];
 		#elseif js
+		#if haxe4
+		return js.Syntax.code("Date");
+		#else
 		return untyped __js__("Date");
+		#end
 		#end
 		return null;
 	}

--- a/src/yaml/util/Dates.hx
+++ b/src/yaml/util/Dates.hx
@@ -36,7 +36,11 @@ class Dates
 		#elseif flash
 		return untyped _global["Date"];
 		#elseif js
+		#if haxe4
+		return js.Syntax.code("Date");
+		#else
 		return untyped __js__("Date");
+		#end
 		#end
 		return null;
 	}
@@ -54,7 +58,11 @@ class Dates
 	public static function toISOString(date:Date):String
 	{
 		var NativeDate = getNativeDate();
+		#if haxe4
+		var d = js.Syntax.construct(NativeDate, date.getTime());
+		#else
 		var d = untyped __new__(NativeDate, date.getTime());
+		#end
 
 		return d.getUTCFullYear() + '-'
 			+ StringTools.lpad("" + (d.getUTCMonth() + 1), "0", 2) + '-'

--- a/src/yaml/util/Ints.hx
+++ b/src/yaml/util/Ints.hx
@@ -102,8 +102,13 @@ class Ints
 
 		#if js
 		
+		#if haxe4
+		var v = js.Syntax.code("parseInt")(value, radix);
+		return (js.Syntax.code("isNaN")(v)) ? null : v;
+		#else
 		var v = untyped __js__("parseInt")(value, radix);
 		return (untyped __js__("isNaN")(v)) ? null : v;
+		#end
 		
 		#elseif flash9
 		


### PR DESCRIPTION
Since recent Haxe 4.1.0 nightlies, there are deprecation warnings for `untyped __js__` usage:

```
Warning : __js__ is deprecated, use js.Syntax.code instead
```

`js.Syntax` is already available since Haxe 4.0 though.