### PR TITLE
Fix HashLink issues related to Parser.hx

### DIFF
--- a/src/yaml/Parser.hx
+++ b/src/yaml/Parser.hx
@@ -247,11 +247,6 @@ class Parser
 			tagMap.set(handle, prefix);
 		});
 
-		if (validate && PATTERN_NON_PRINTABLE.match(this.input))
-		{
-			throwError('the stream contains non-printable characters');
-		}
-
 		while (CHAR_SPACE == character)
 		{
 			lineIndent += 1;
@@ -647,7 +642,7 @@ class Parser
 
 		if (result != null) 
 		{
-			#if sys
+			#if (sys && !hl)
 			result = Utf8.decode(result); // convert back into native encoding
 			#end
 			return true;
@@ -689,7 +684,7 @@ class Parser
 				} 
 				else 
 				{
-					#if sys
+					#if (sys && !hl)
 					result = Utf8.decode(result);
 					#end
 					return true;
@@ -738,7 +733,7 @@ class Parser
 				captureSegment(captureStart, position, true);
 				character = Utf8.charCodeAt(input, ++position);
 
-				#if sys
+				#if (sys && !hl)
 				result = Utf8.decode(result);
 				#end
 				return true;
@@ -973,7 +968,7 @@ class Parser
 						try
 						{
 							_result = type.resolve(result, usingMaps, false);
-							#if sys
+							#if (sys && !hl)
 							if (Std.is(_result, String))
 								_result = Utf8.decode(_result);
 							#end
@@ -1002,7 +997,7 @@ class Parser
 					try
 					{
 						_result = t.resolve(result, usingMaps, true);
-						#if sys
+						#if (sys && !hl)
 						if (Std.is(_result, String))
 							_result = Utf8.decode(_result);
 						#end
@@ -1309,7 +1304,7 @@ class Parser
 			captureSegment(captureStart, position, false);
 		}
 		
-		#if sys
+		#if (sys && !hl)
 		result = Utf8.decode(result);
 		#end
 
@@ -1993,21 +1988,11 @@ class Parser
 		hash.set(CHAR_CAPITAL_U, 8);
 		hash;
 	};
-
-	#if (eval || neko || cpp || display)
-	public static var PATTERN_NON_PRINTABLE         = ~/[\x{00}-\x{08}\x{0B}\x{0C}\x{0E}-\x{1F}\x{7F}-\x{84}\x{86}-\x{9F}\x{FFFE}\x{FFFF}]/u;
-	#elseif (js || flash9 || java)
-	public static var PATTERN_NON_PRINTABLE         = ~/[\x00-\x08\x0B\x0C\x0E-\x1F\x7F-\x84\x86-\x9F\uD800-\uDFFF\uFFFE\uFFFF]/u;	
-	#else
-	#error "Compilation target not supported due to lack of Unicode RegEx support."
-	#end
 	
-	#if (eval || neko || cpp || display)
+	#if (js || flash9 || java)
 	public static var PATTERN_NON_ASCII_LINE_BREAKS = ~/[\x{85}\x{2028}\x{2029}]/u;
-	#elseif (js || flash9 || java)
-	public static var PATTERN_NON_ASCII_LINE_BREAKS = ~/[\x85\u2028\u2029]/u;
 	#else
-	#error "Compilation target not supported due to lack of Unicode RegEx support."
+	public static var PATTERN_NON_ASCII_LINE_BREAKS = ~/[\x85\u2028\u2029]/u;
 	#end
 	
 	public static var PATTERN_FLOW_INDICATORS       = ~/[,\[\]\{\}]/u;

--- a/src/yaml/Parser.hx
+++ b/src/yaml/Parser.hx
@@ -1989,9 +1989,9 @@ class Parser
 		hash;
 	};
 	
-	#if (js || flash9 || java)
+	#if (eval || neko || cpp || hl || display)
 	public static var PATTERN_NON_ASCII_LINE_BREAKS = ~/[\x{85}\x{2028}\x{2029}]/u;
-	#else
+	#elseif (js || flash9 || java)
 	public static var PATTERN_NON_ASCII_LINE_BREAKS = ~/[\x85\u2028\u2029]/u;
 	#end
 	

--- a/src/yaml/Parser.hx
+++ b/src/yaml/Parser.hx
@@ -1855,11 +1855,6 @@ class Parser
 		composeNode(lineIndent - 1, CONTEXT_BLOCK_OUT, false, true);
 		skipSeparationSpace(true, -1);
 
-		if (validate && checkLineBreaks && PATTERN_NON_ASCII_LINE_BREAKS.match(yaml.util.Utf8.substring(input, documentStart, position)))
-		{
-			throwWarning('non-ASCII line breaks are interpreted as content');
-		}
-
 		output(result);
 
 		if (position == lineStart && testDocumentSeparator())
@@ -1988,12 +1983,6 @@ class Parser
 		hash.set(CHAR_CAPITAL_U, 8);
 		hash;
 	};
-	
-	#if (eval || neko || cpp || hl || display)
-	public static var PATTERN_NON_ASCII_LINE_BREAKS = ~/[\x{85}\x{2028}\x{2029}]/u;
-	#elseif (js || flash9 || java)
-	public static var PATTERN_NON_ASCII_LINE_BREAKS = ~/[\x85\u2028\u2029]/u;
-	#end
 	
 	public static var PATTERN_FLOW_INDICATORS       = ~/[,\[\]\{\}]/u;
 	public static var PATTERN_TAG_HANDLE            = ~/^(?:!|!!|![a-z\-]+!)$/iu;


### PR DESCRIPTION
Removed a regex check because it broke on Hashlink
and the characters included in the regex should never be in the file in the first place

Also had to exclude hashlink from Utf8.decode since it causes throws that can crash the program